### PR TITLE
refactor/seperateFetch : fetch (+에러핸들링) 분리하기

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [ opened, reopened, edited ]
   push:
     branches-ignore:
       - main
@@ -58,7 +58,7 @@ jobs:
             console.log('pr', pr, 'issues2', issues2)
 
             github.rest.issues.createComment({
-              issue_number: pr,
+              issue_number: ${{github.event.issue.number}},
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: "🚀 Preview : [Link](${{env.DEPLOYMENT_URL}})"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
             console.log('pr', pr, 'issues2', issues2)
 
             github.rest.issues.createComment({
-              issue_number: ${{github.event.issue.number}},
+              issue_number: pr,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: "🚀 Preview : [Link](${{env.DEPLOYMENT_URL}})"

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,12 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JavaScript">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PublishConfigData" autoUpload="Always" remoteFilesAllowedToDisappearOnAutoupload="false" autoUploadExternalChanges="true">
+    <option name="myAutoUpload" value="ALWAYS" />
+  </component>
+</project>

--- a/.idea/dev-blog.iml
+++ b/.idea/dev-blog.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="Stylelint" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/dev-blog.iml" filepath="$PROJECT_DIR$/.idea/dev-blog.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
+    <option name="myRunOnSave" value="true" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -1,5 +1,7 @@
 import { API_URL } from '../constants/common'
 
+const API_ARTICLE_URL = `${API_URL}/api/articles`
+
 export interface ArticleContentInterface {
   text: string
   html: string
@@ -30,7 +32,7 @@ export interface GetArticlesResponseInterface {
 }
 
 export const createArticle = async (article: ArticleInterface) => {
-  const res = await fetch(`${API_URL}/api/articles`, {
+  const res = await fetch(API_ARTICLE_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -42,7 +44,7 @@ export const createArticle = async (article: ArticleInterface) => {
 }
 
 export const getArticleById = async (id: string) => {
-  const res = await fetch(`${API_URL}/api/articles/${id}`, {
+  const res = await fetch(`${API_ARTICLE_URL}/${id}`, {
     cache: 'no-store',
   })
 
@@ -50,7 +52,7 @@ export const getArticleById = async (id: string) => {
 }
 
 export const getArticles = async () => {
-  const res = await fetch(`${API_URL}/api/articles`, {
+  const res = await fetch(API_ARTICLE_URL, {
     cache: 'no-store',
   })
 
@@ -61,7 +63,7 @@ export const putArticleById = async (
   id: string,
   revisedArticle: RevisedArticleInterface,
 ) => {
-  const res = await fetch(`${API_URL}/api/articles/${id}`, {
+  const res = await fetch(`${API_ARTICLE_URL}/${id}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -73,7 +75,7 @@ export const putArticleById = async (
 }
 
 export const deleteArticleById = async (id: string) => {
-  const res = await fetch(`${API_URL}/api/articles?id=${id}`, {
+  const res = await fetch(`${API_ARTICLE_URL}?id=${id}`, {
     method: 'DELETE',
   })
 

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -29,6 +29,18 @@ interface GetArticlesResponseInterface {
   articles: GetArticleInterface[]
 }
 
+export const createArticleById = async (article: ArticleInterface) => {
+  const res = await fetch(`${API_URL}/api/articles`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(article),
+  })
+
+  return res
+}
+
 export const getArticleById = async (
   id: string,
 ): Promise<GetArticleResponseInterface | undefined> => {
@@ -75,3 +87,5 @@ export const putArticleById = async (
 
   return res
 }
+
+export const deleteArticleById = async () => {}

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -25,7 +25,7 @@ interface GetArticleResponseInterface {
   article: GetArticleInterface
 }
 
-interface GetArticlesResponseInterface {
+export interface GetArticlesResponseInterface {
   articles: GetArticleInterface[]
 }
 
@@ -55,22 +55,12 @@ export const getArticleById = async (
   return res.json()
 }
 
-export const getArticles = async (): Promise<
-  GetArticlesResponseInterface | undefined
-> => {
-  try {
-    const res = await fetch(`${API_URL}/api/articles`, {
-      cache: 'no-store',
-    })
+export const getArticles = async () => {
+  const res = await fetch(`${API_URL}/api/articles`, {
+    cache: 'no-store',
+  })
 
-    if (!res.ok) {
-      throw new Error('Failed to fetch articles')
-    }
-
-    return res.json()
-  } catch (error) {
-    console.log('Error loading articles:', error)
-  }
+  return res
 }
 
 export const putArticleById = async (

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -1,8 +1,18 @@
 import { API_URL } from '../constants/common'
 
+export interface ArticleContentInterface {
+  text: string
+  html: string
+}
+
 export interface ArticleInterface {
   title: string
-  content: { text: string; html: string }
+  content: ArticleContentInterface
+}
+
+export interface RevisedArticleInterface {
+  newTitle: string
+  newContent: ArticleContentInterface
 }
 
 export interface GetArticleInterface extends ArticleInterface {
@@ -19,7 +29,7 @@ interface GetArticlesResponseInterface {
   articles: GetArticleInterface[]
 }
 
-export const fetchArticleById = async (
+export const getArticleById = async (
   id: string,
 ): Promise<GetArticleResponseInterface | undefined> => {
   const res = await fetch(`${API_URL}/api/articles/${id}`, {
@@ -49,4 +59,19 @@ export const getArticles = async (): Promise<
   } catch (error) {
     console.log('Error loading articles:', error)
   }
+}
+
+export const putArticleById = async (
+  id: string,
+  revisedArticle: RevisedArticleInterface,
+) => {
+  const res = await fetch(`${API_URL}/api/articles/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(revisedArticle),
+  })
+
+  return res
 }

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -29,7 +29,7 @@ export interface GetArticlesResponseInterface {
   articles: GetArticleInterface[]
 }
 
-export const createArticleById = async (article: ArticleInterface) => {
+export const createArticle = async (article: ArticleInterface) => {
   const res = await fetch(`${API_URL}/api/articles`, {
     method: 'POST',
     headers: {

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -21,7 +21,7 @@ export interface GetArticleInterface extends ArticleInterface {
   updatedAt: string
 }
 
-interface GetArticleResponseInterface {
+export interface GetArticleResponseInterface {
   article: GetArticleInterface
 }
 
@@ -41,18 +41,12 @@ export const createArticleById = async (article: ArticleInterface) => {
   return res
 }
 
-export const getArticleById = async (
-  id: string,
-): Promise<GetArticleResponseInterface | undefined> => {
+export const getArticleById = async (id: string) => {
   const res = await fetch(`${API_URL}/api/articles/${id}`, {
     cache: 'no-store',
   })
 
-  if (!res.ok) {
-    throw new Error(`HTTP error! Status: ${res.status}`)
-  }
-
-  return res.json()
+  return res
 }
 
 export const getArticles = async () => {

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -19,22 +19,18 @@ interface GetArticlesResponseInterface {
   articles: GetArticleInterface[]
 }
 
-export const getArticleById = async (
+export const fetchArticleById = async (
   id: string,
 ): Promise<GetArticleResponseInterface | undefined> => {
-  try {
-    const res = await fetch(`${API_URL}/api/articles/${id}`, {
-      cache: 'no-store',
-    })
+  const res = await fetch(`${API_URL}/api/articles/${id}`, {
+    cache: 'no-store',
+  })
 
-    if (!res.ok) {
-      throw new Error('Failed to fetch an article.')
-    }
-
-    return res.json()
-  } catch (error) {
-    console.log(error)
+  if (!res.ok) {
+    throw new Error(`HTTP error! Status: ${res.status}`)
   }
+
+  return res.json()
 }
 
 export const getArticles = async (): Promise<

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -88,4 +88,10 @@ export const putArticleById = async (
   return res
 }
 
-export const deleteArticleById = async () => {}
+export const deleteArticleById = async (id: string) => {
+  const res = await fetch(`${API_URL}/api/articles?id=${id}`, {
+    method: 'DELETE',
+  })
+
+  return res
+}

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -1,21 +1,27 @@
 import { notFound } from 'next/navigation'
 
-import { getArticleById } from '@/apis/articles'
+import { getArticleById, GetArticleResponseInterface } from '@/apis/articles'
 import Article from '@/containers/Article'
 
 const ArticlePage = async ({ params }: { params: { id: string } }) => {
   const { id } = params
 
-  const getArticle = async () => {
+  const loadedArticle = async (): Promise<
+    GetArticleResponseInterface | undefined
+  > => {
     try {
       const res = await getArticleById(id)
-      return res
+      if (!res.ok) {
+        throw new Error(`HTTP error! Status: ${res.status}`)
+      }
+
+      return res.json()
     } catch (error) {
       console.log(error)
     }
   }
 
-  const data = await getArticle()
+  const data = await loadedArticle()
   if (!data) return notFound()
 
   const { article } = data

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -1,21 +1,21 @@
 import { notFound } from 'next/navigation'
 
-import { fetchArticleById } from '@/apis/articles'
+import { getArticleById } from '@/apis/articles'
 import Article from '@/containers/Article'
 
 const ArticlePage = async ({ params }: { params: { id: string } }) => {
   const { id } = params
 
-  const getArticleById = async () => {
+  const getArticle = async () => {
     try {
-      const res = await fetchArticleById(id)
+      const res = await getArticleById(id)
       return res
     } catch (error) {
       console.log(error)
     }
   }
 
-  const data = await getArticleById()
+  const data = await getArticle()
   if (!data) return notFound()
 
   const { article } = data

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -1,13 +1,23 @@
 import { notFound } from 'next/navigation'
 
+import { fetchArticleById } from '@/apis/articles'
 import Article from '@/containers/Article'
-import { getArticleById } from '@/apis/articles'
 
 const ArticlePage = async ({ params }: { params: { id: string } }) => {
   const { id } = params
-  const data = await getArticleById(id)
 
+  const getArticleById = async () => {
+    try {
+      const res = await fetchArticleById(id)
+      return res
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const data = await getArticleById()
   if (!data) return notFound()
+
   const { article } = data
 
   return <Article article={article} />

--- a/src/app/editArticle/[id]/page.tsx
+++ b/src/app/editArticle/[id]/page.tsx
@@ -4,14 +4,14 @@ import { use } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { API_URL } from '@/constants/common'
-import { ArticleInterface, getArticleById } from '@/apis/articles'
+import { ArticleInterface, fetchArticleById } from '@/apis/articles'
 
 import ArticleForm from '@/components/ArticleForm'
 import NotFound from '../../not-found'
 
 const EditArticle = ({ params: { id } }: { params: { id: string } }) => {
   const router = useRouter()
-  const data = use(getArticleById(id))
+  const data = use(fetchArticleById(id))
 
   if (!data) return <NotFound />
   const {

--- a/src/app/editArticle/[id]/page.tsx
+++ b/src/app/editArticle/[id]/page.tsx
@@ -12,7 +12,7 @@ import ArticleForm from '@/components/ArticleForm'
 
 const EditArticle = async ({ params: { id } }: { params: { id: string } }) => {
   const router = useRouter()
-  const getArticle = async () => {
+  const loadedArticle = async () => {
     try {
       const res = await getArticleById(id)
       return res
@@ -21,7 +21,7 @@ const EditArticle = async ({ params: { id } }: { params: { id: string } }) => {
     }
   }
 
-  const data = await getArticle()
+  const data = await loadedArticle()
   if (!data) return notFound()
   const {
     article: { title: originalTitle, content: originalContent },

--- a/src/app/editArticle/[id]/page.tsx
+++ b/src/app/editArticle/[id]/page.tsx
@@ -1,19 +1,26 @@
 'use client'
 
-import { use } from 'react'
-import { useRouter } from 'next/navigation'
+import { notFound, useRouter } from 'next/navigation'
 
 import { API_URL } from '@/constants/common'
 import { ArticleInterface, fetchArticleById } from '@/apis/articles'
 
 import ArticleForm from '@/components/ArticleForm'
-import NotFound from '../../not-found'
 
-const EditArticle = ({ params: { id } }: { params: { id: string } }) => {
+const EditArticle = async ({ params: { id } }: { params: { id: string } }) => {
   const router = useRouter()
-  const data = use(fetchArticleById(id))
+  const getArticleById = async () => {
+    try {
+      const res = await fetchArticleById(id)
+      return res
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
-  if (!data) return <NotFound />
+  const data = await getArticleById()
+
+  if (!data) return notFound()
   const {
     article: { title: originalTitle, content: originalContent },
   } = data

--- a/src/app/editArticle/[id]/page.tsx
+++ b/src/app/editArticle/[id]/page.tsx
@@ -2,48 +2,44 @@
 
 import { notFound, useRouter } from 'next/navigation'
 
-import { API_URL } from '@/constants/common'
-import { ArticleInterface, fetchArticleById } from '@/apis/articles'
+import {
+  ArticleInterface,
+  getArticleById,
+  putArticleById,
+} from '@/apis/articles'
 
 import ArticleForm from '@/components/ArticleForm'
 
 const EditArticle = async ({ params: { id } }: { params: { id: string } }) => {
   const router = useRouter()
-  const getArticleById = async () => {
+  const getArticle = async () => {
     try {
-      const res = await fetchArticleById(id)
+      const res = await getArticleById(id)
       return res
     } catch (error) {
       console.log(error)
     }
   }
 
-  const data = await getArticleById()
-
+  const data = await getArticle()
   if (!data) return notFound()
   const {
     article: { title: originalTitle, content: originalContent },
   } = data
 
   const handleSubmit = async (article: ArticleInterface) => {
-    const { title, content } = article
+    const { title: newTitle, content: newContent } = article
 
-    if (!title || !content) {
+    if (!newTitle || !newContent) {
       alert('Title and description are required')
       return
     }
 
     try {
-      const res = await fetch(`${API_URL}/api/articles/${id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ newTitle: title, newContent: content }),
-      })
+      const res = await putArticleById(id, { newTitle, newContent })
 
       if (!res.ok) {
-        throw new Error('Failed to update article')
+        throw new Error(`HTTP error! Status: ${res.status}`)
       }
 
       router.push(`/${id}`)

--- a/src/app/editArticle/[id]/page.tsx
+++ b/src/app/editArticle/[id]/page.tsx
@@ -5,6 +5,7 @@ import { notFound, useRouter } from 'next/navigation'
 import {
   ArticleInterface,
   getArticleById,
+  GetArticleResponseInterface,
   putArticleById,
 } from '@/apis/articles'
 
@@ -12,10 +13,17 @@ import ArticleForm from '@/components/ArticleForm'
 
 const EditArticle = async ({ params: { id } }: { params: { id: string } }) => {
   const router = useRouter()
-  const loadedArticle = async () => {
+  const loadedArticle = async (): Promise<
+    GetArticleResponseInterface | undefined
+  > => {
     try {
       const res = await getArticleById(id)
-      return res
+
+      if (!res.ok) {
+        throw new Error(`HTTP error! Status: ${res.status}`)
+      }
+
+      return res.json()
     } catch (error) {
       console.log(error)
     }

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -26,12 +26,12 @@ const WritePage = () => {
     try {
       const res = await createArticleById(article)
 
-      if (res.ok) {
-        const { message: articleId } = await res.json()
-        router.push(`/${articleId}`)
-      } else {
+      if (!res.ok) {
         throw new Error('Failed to create an article')
       }
+
+      const { message: articleId } = await res.json()
+      router.push(`/${articleId}`)
     } catch (error) {
       console.log(error)
     }

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -3,8 +3,7 @@
 import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 
-import { ArticleInterface } from '@/apis/articles'
-import { API_URL } from '@/constants/common'
+import { ArticleInterface, createArticleById } from '@/apis/articles'
 
 const DynamicArticleForm = dynamic(
   () => {
@@ -25,13 +24,7 @@ const WritePage = () => {
     }
 
     try {
-      const res = await fetch(`${API_URL}/api/articles`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ title, content }),
-      })
+      const res = await createArticleById(article)
 
       if (res.ok) {
         const { message: articleId } = await res.json()

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 
-import { ArticleInterface, createArticleById } from '@/apis/articles'
+import { ArticleInterface, createArticle } from '@/apis/articles'
 
 const DynamicArticleForm = dynamic(
   () => {
@@ -24,7 +24,7 @@ const WritePage = () => {
     }
 
     try {
-      const res = await createArticleById(article)
+      const res = await createArticle(article)
 
       if (!res.ok) {
         throw new Error('Failed to create an article')

--- a/src/containers/Article/DeleteButton/index.tsx
+++ b/src/containers/Article/DeleteButton/index.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 
-import { API_URL } from '@/constants/common'
+import { deleteArticleById } from '@/apis/articles'
 
 const DeleteButton = ({ id }: { id: string }) => {
   const router = useRouter()
@@ -13,9 +13,7 @@ const DeleteButton = ({ id }: { id: string }) => {
     if (!confirmed) return
 
     try {
-      const res = await fetch(`${API_URL}/api/articles?id=${id}`, {
-        method: 'DELETE',
-      })
+      const res = await deleteArticleById(id)
 
       if (!res.ok) {
         throw new Error('Failed to delete an article.')

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -1,9 +1,24 @@
 import Link from 'next/link'
 
-import { getArticles } from '@/apis/articles'
+import { getArticles, GetArticlesResponseInterface } from '@/apis/articles'
 
 const Home = async () => {
-  const data = await getArticles()
+  const loadedArticles = async (): Promise<
+    GetArticlesResponseInterface | undefined
+  > => {
+    try {
+      const res = await getArticles()
+
+      if (!res.ok) {
+        throw new Error('Failed to fetch articles')
+      }
+
+      return res.json()
+    } catch (error) {
+      console.log('Error loading articles:', error)
+    }
+  }
+  const data = await loadedArticles()
 
   if (!data) return
 


### PR DESCRIPTION
# What is this PR?

- fetch 메소드 분리하기

# Changes

- 오직 fetch 메소드만 apis 폴더에 존재
    
    → 에러 핸들링(try/catch 등)은 모두 호출단에서 처리하도록 리팩토링
    

# Notes

- 에러 핸들링은 다른 PR에서 할 예정

# Questions

- fetch와 에러 핸들링을 이런 식으로 분리하면 될까요?